### PR TITLE
Workaround missing pkgconfig for zlib on darwin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -139,7 +139,11 @@ if (thread_dep.found())
    c_args = ['-D_REENTRANT']
 endif
 
-zlib_dep = dependency('zlib', required: false)
+if host_machine.system() == 'darwin'
+    zlib_dep = cc.find_library('z', required: false)
+else
+    zlib_dep = dependency('zlib', required: false)
+endif
 if zlib_dep.found()
   cdata.set('HAVE_LIBZ', 1)
 endif


### PR DESCRIPTION
darwin does not include a pkgconfig for zlib even if it provides the corresponding headers and libraries (see https://github.com/mesonbuild/meson/issues/2654). As a result zlib_dep is not found, and the final build fails with missing symbols. This change is to support locating the same library using the compiler object instead but guarded to do so only on darwin.